### PR TITLE
Clear existing content between start/end tags before injection

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -84,6 +84,18 @@ module.exports = function(grunt) {
         }
       });
 
+      // Clear existing content between injectors
+      var templateContent = options.templateString || grunt.file.read(template),
+        templateOriginal = templateContent;
+
+      var re = getInjectorTagsRegExp(options.starttag, options.endtag);
+      templateContent = templateContent.replace(re, function (match, indent, starttag, content, endtag) {
+        return indent + starttag + '\n' + indent + endtag;
+      });
+
+      if (templateContent !== templateOriginal || !grunt.file.exists(destination)) {
+        grunt.file.write(destination, templateContent);
+      }
     });
 
     /**


### PR DESCRIPTION
Thanks for the great work on this task, its very helpful.

I ran into an issue where if you delete a file that was injected, the injector will not clear the left over reference the next time it's run if it can't match any files to inject.

In other words, if I have 

```
 <!-- injector:js -->
 <script src="script.js">
 <!-- endinjector -->   
```

And i delete the script.js file, the next time the task runs it won't match any files to be injected, so it wont delete the incorrect script tag.

This PR fixes this by clearing the content between all start and the end tags before injecting files.
