### PR TITLE
Allow for multiple uses of {{ext}} in the Start and End Tag option

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -157,7 +157,7 @@ function getInjectorTagsRegExp (starttag, endtag) {
 }
 
 function getTag (tag, ext) {
-  return tag.replace('{{ext}}', ext);
+  return tag.replace(new RegExp( escapeForRegExp('{{ext}}'), 'g'), ext);
 }
 
 function getFilesFromBower (bowerFile) {


### PR DESCRIPTION
Changed the replace in `getInjectorTagsRegExp` to a global regular expression. This allows the `{{ext}}` replacement to be used multiple places in the start or end tag. This is useful for making the tags the same as the `usemin` start and end tags. Example:

``` html
    <!-- build:css css/app.css -->
    ...
    <!-- endbuild -->
    ...
    <!-- build:js js/app.js -->
    ...
    <!-- endbuild -->
```

Normally two injector tasks would be needed, but with the changes, they can be in the form:

``` javascript
    {
      localDeps: {
         options: {
          starttag: '<!-- build:{{ext}} {{ext}}/app.{{ext}} -->',
          endtag: '<!-- endbuild -->'
         }
      }
    }
```
