### PR TITLE
use system line feed for inserted lines

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -136,7 +136,7 @@ module.exports = function(grunt) {
           var re = getInjectorTagsRegExp(starttag, endtag);
           templateContent = templateContent.replace(re, function (match, indent, starttag, content, endtag) {
             grunt.log.writeln('Injecting ' + key.green + ' files ' + ('(' + sources.length + ' files)').grey);
-            return indent + starttag + getIndentedTransformations(sources, indent) + endtag;
+            return indent + starttag + getIndentedTransformations(sources, indent, grunt.util.linefeed) + endtag;
           });
         });
 
@@ -235,12 +235,12 @@ function escapeForRegExp (str) {
   return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
 }
 
-function getIndentedTransformations (sources, indent) {
+function getIndentedTransformations (sources, indent, linefeed) {
   var transformations = sources.map(function (s) {
     return s.transformed;
   });
   transformations.unshift('');
   transformations.push('');
-  return transformations.join('\n' + indent);
+  return transformations.join(linefeed + indent);
 }
 


### PR DESCRIPTION
grunt-injector always inserts lines with unix style line feed '\n'. This breaks our build on windows computers, we want to concat all <script> tags inserted by grunt-injector with a useminPrepare/usemin task.

Please pull so that we dont need to publish our own fork on npm registry :)
