### PR TITLE
Custom targets with corresponding injector tag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -181,7 +181,28 @@ module.exports = function(grunt) {
         },
         src: ['test/fixtures/script.js', 'test/fixtures/style.css', 'test/fixtures/component.html'],
         dest: 'tmp/customSort.js'
+      },
+
+      groupByTarget: {
+        options: {
+          template: 'test/fixtures/index-grouped.html',
+          groupByTarget: true
+        },
+        files: {
+          'tmp/groupByTarget.html': ['test/fixtures/*.js', 'test/fixtures/*.css', 'test/fixtures/component.html', '!test/fixtures/*.min.*']
+        }
+      },
+      groupByTargetWithCustomTarget: {
+        options: {
+          template: 'test/fixtures/index-grouped.html',
+          groupByTarget: true,
+          target: 'customTarget'
+        },
+        files: {
+          'tmp/groupByTargetWithCustomTarget.html': ['test/fixtures/*.js', 'test/fixtures/*.css', 'test/fixtures/component.html', '!test/fixtures/*.min.*']
+        }
       }
+
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ If set the given function is used as the compareFunction for the array sort func
 
 **N.B.** Shouldn't be used in conjunction with a `bower.json` file as source, because [wiredep](https://github.com/stephenplusplus/wiredep), which collects Bower installed dependencies, has some intelligent sorting built in.
 
+#### options.groupByTarget
+Type: `String`
+Default value: `false`
+
+When set to `true` the start tag behaviour is changed. Instead of using `<!-- injector:{{ext}} -->` to group files by there extension, you can specify your own group key like `<!-- injector:customKey -->`. All files are inserted between the tags regardless of the file extension. By default the attribute name as specified in the guntfile is used. (See example below.)
+
+#### options.target
+Type: `String`
+Default value: `false`
+
+By default the attribute name as specified in the guntfile is used. If you want use a different keyname you can use `target: 'yourKeyName'`. (See example below.)
+
+**N.B.** groupByTarget must be set to `true`.
+
 ### Usage Examples
 
 #### Injecting into html file with default options
@@ -145,6 +159,12 @@ index.html:
 
   <!-- injector:js -->
   <!-- endinjector -->
+  
+  <!-- injector:groupA -->
+  <!-- endinjector -->
+  
+  <!-- injector:yourKeyName -->
+  <!-- endinjector -->
 </body>
 </html>
 ```
@@ -155,6 +175,23 @@ grunt.initConfig({
   injector: {
     options: {},
     local_dependencies: {
+      files: {
+        'index.html': ['**/*.js', '**/*.css'],
+      }
+    },
+    groupA:{
+      options: {
+        groupByTarget: true
+      },
+      files: {
+        'index.html': ['**/*.js', '**/*.css'],
+      }
+    },
+    groupB:{
+      options: {
+        groupByTarget: true,
+        target: 'yourKeyName'
+      },
       files: {
         'index.html': ['**/*.js', '**/*.css'],
       }

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -116,9 +116,10 @@ module.exports = function(grunt) {
         // Remove possible duplicates:
         files = _.uniq(files);
 
-        var target = (options.groupByTarget)) ? obj.key : me.target;
-
         files.forEach(function (obj) {
+          
+          var target = options.groupByTarget ? me.target : obj.key;
+
           // Get start and end tag for each file:
           obj.starttag = getTag(options.starttag, target);
           obj.endtag = getTag(options.endtag, target);

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -34,6 +34,7 @@ module.exports = function(grunt) {
       })(this),
       starttag: '<!-- injector:{{ext}} -->',
       endtag: '<!-- endinjector -->',
+      groupByTarget: false,
       lineEnding: '\n',
       transform: function (filepath) {
         var e = ext(filepath);
@@ -115,10 +116,12 @@ module.exports = function(grunt) {
         // Remove possible duplicates:
         files = _.uniq(files);
 
+        var target = (options.groupByTarget)) ? obj.key : me.target;
+
         files.forEach(function (obj) {
           // Get start and end tag for each file:
-          obj.starttag = getTag(options.starttag, me.target);
-          obj.endtag = getTag(options.endtag, me.target);
+          obj.starttag = getTag(options.starttag, target);
+          obj.endtag = getTag(options.endtag, target);
 
           // Fix filename (remove ignorepaths and such):
           var file = obj.path;

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -118,8 +118,8 @@ module.exports = function(grunt) {
 
         files.forEach(function (obj) {
           
-          var target = options.groupByTarget ? me.target : obj.key;
-
+          var target = options.groupByTarget ? (options.target ? options.target : me.target) : obj.key;
+          
           // Get start and end tag for each file:
           obj.starttag = getTag(options.starttag, target);
           obj.endtag = getTag(options.endtag, target);

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
 
   grunt.registerMultiTask('injector', 'Inject references to files into other files (think scripts and stylesheets into an html file)', function() {
     // Merge task-specific and/or target-specific options with these defaults.
-    var options = this.options({
+    var me = this,
+    options = this.options({
       min: false,
       template: null,
       bowerPrefix: null,
@@ -116,8 +117,8 @@ module.exports = function(grunt) {
 
         files.forEach(function (obj) {
           // Get start and end tag for each file:
-          obj.starttag = getTag(options.starttag, obj.key);
-          obj.endtag = getTag(options.endtag, obj.key);
+          obj.starttag = getTag(options.starttag, me.target);
+          obj.endtag = getTag(options.endtag, me.target);
 
           // Fix filename (remove ignorepaths and such):
           var file = obj.path;

--- a/test/expected/groupByTarget.html
+++ b/test/expected/groupByTarget.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>grunt-injector</title>
+</head>
+<body>
+  <!-- injector:groupByTarget -->
+  <script src="/test/fixtures/script.js"></script>
+  <script src="/test/fixtures/script2.js"></script>
+  <link rel="stylesheet" href="/test/fixtures/style.css">
+  <link rel="import" href="/test/fixtures/component.html">
+  <!-- endinjector -->
+
+  <!-- injector:customTarget -->
+  <!-- endinjector -->
+</body>
+</html>

--- a/test/expected/groupByTargetWithCustomTarget.html
+++ b/test/expected/groupByTargetWithCustomTarget.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>grunt-injector</title>
+</head>
+<body>
+  <!-- injector:groupByTarget -->
+  <!-- endinjector -->
+
+  <!-- injector:customTarget -->
+  <script src="/test/fixtures/script.js"></script>
+  <script src="/test/fixtures/script2.js"></script>
+  <link rel="stylesheet" href="/test/fixtures/style.css">
+  <link rel="import" href="/test/fixtures/component.html">
+  <!-- endinjector -->
+</body>
+</html>

--- a/test/fixtures/index-grouped.html
+++ b/test/fixtures/index-grouped.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>grunt-injector</title>
+</head>
+<body>
+  <!-- injector:groupByTarget -->
+  <!-- endinjector -->
+
+  <!-- injector:customTarget -->
+  <!-- endinjector -->
+</body>
+</html>

--- a/test/injector_test.js
+++ b/test/injector_test.js
@@ -170,5 +170,23 @@ exports.injector = {
     test.equal(actual, expected, 'should inject files ordered with a custom sorting function.');
 
     test.done();
+  },
+  groupByTarget: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/groupByTarget.html');
+    var expected = grunt.file.read('test/expected/groupByTarget.html');
+    test.equal(actual, expected, 'should inject stylesheets, scripts and html components into the <!-- injector:groupByTarget --> wrapper.');
+
+    test.done();
+  },
+  groupByTargetWithCustomTarget: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/groupByTargetWithCustomTarget.html');
+    var expected = grunt.file.read('test/expected/groupByTargetWithCustomTarget.html');
+    test.equal(actual, expected, 'should inject stylesheets, scripts and html components into the <!-- injector:customTarget --> wrapper.');
+
+    test.done();
   }
 };


### PR DESCRIPTION
As mentioned in #20 it might be a good idea to group files by the target name instead of the file extension.

This allows you to make multiple 'groups' of injected files.

**Gruntfile**

``` javascript
injector: {
  myControllers: {
    files: {
      '<%= yeoman.app %>/index.html': ['<%= yeoman.app %>/scripts/controllers/**/*.js']
    }
  },
  myServices: {
    files: {
      '<%= yeoman.app %>/index.html': ['<%= yeoman.app %>/scripts/services/**/*.js']
    }
  }
}
```

**HTML**

``` html
<!-- injector:myControllers -->
<!-- endinjector -->

<!-- injector:myServices -->
<!-- endinjector -->
```

If you want, it's also possible to inject multiple file types in a single group.. 
