### PR TITLE
added a type attribute to the script tag returned by transform

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -39,7 +39,7 @@ module.exports = function(grunt) {
         if (e === 'css') {
           return '<link rel="stylesheet" href="' + filepath + '">';
         } else if (e === 'js') {
-          return '<script src="' + filepath + '"></script>';
+          return '<script type="application/javascript" src="' + filepath + '"></script>';
         } else if (e === 'html') {
           return '<link rel="import" href="' + filepath + '">';
         }


### PR DESCRIPTION
I added the type attribute to make it wcm compliant. Was there a specific reason to let it out? My webapp didn't like the fact that the attribute was missing and the browser kept reloading the scripts.