### PR TITLE
Check for minified file before making file relative

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -121,12 +121,12 @@ module.exports = function(grunt) {
 
           // Fix filename (remove ignorepaths and such):
           var file = obj.path;
+          file = makeMinifiedIfNeeded(options.min, file);
           if (options.relative) {
             var base =  path.dirname(destination);
             file = path.relative(base, file);
           }
           file = unixify(file);
-          file = makeMinifiedIfNeeded(options.min, file);
           if (options.ignorePath || obj.ignore) {
             file = removeBasePath(toArray(options.ignorePath).concat(toArray(obj.ignore)), file);
           }


### PR DESCRIPTION
Currently, the check for a minified file (if `options.min` is true) is done on the resolved relative path (if `options.relative` is true).
This means that the existence check fails.

This PR switches the ordering so that the minified file check is done prior to the relative filepath resolution, fixing the issue.