### PR TITLE
make lineEnding default value to the destination file's line ending

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
       })(this),
       starttag: '<!-- injector:{{ext}} -->',
       endtag: '<!-- endinjector -->',
-      lineEnding: '\n',
+      lineEnding: null,
       transform: function (filepath) {
         var e = ext(filepath);
         if (e === 'css') {
@@ -46,8 +46,20 @@ module.exports = function(grunt) {
       }
     });
 
+    var useDestTpl = false;
     if (!options.template && !options.templateString) {
       grunt.log.writeln('Missing option `template`, using `dest` as template instead'.grey);
+      useDestTpl = true;
+    }
+    
+    if (!options.lineEnding) {
+      var destination = options.template || options.templateString;
+      if (useDestTpl) {
+        destination = options.destFile;
+      }
+      var contents = String(grunt.file.read(destination));
+      var returnType = /\r\n/.test(contents) ? '\r\n' : '\n';
+      options.lineEnding = returnType;
     }
 
     var filesToInject = {};

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -54,10 +54,15 @@ module.exports = function(grunt) {
     
     if (!options.lineEnding) {
       var destination = options.template || options.templateString;
+      var contents = '';
       if (useDestTpl) {
         destination = options.destFile;
       }
-      var contents = String(grunt.file.read(destination));
+      if (options.templateString) {
+        contents = options.templateString;  
+      } else {
+        contents = String(grunt.file.read(destination));    
+      }
       var returnType = /\r\n/.test(contents) ? '\r\n' : '\n';
       options.lineEnding = returnType;
     }


### PR DESCRIPTION
Today's default lineEnding is set to '\n'.
Even though one can change it thanks to the option `option.lineEnding`, it becomes hard to maintain if the build occurs on different platforms.
To improve the line ending behavior, I suggest that the destination/template file decide what should be the end of line for injector.
This is the aim of this PR.