### PR TITLE
Setting default lineEnding to use grunt.util.linefeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Set prefix for file extension when replacing `{{ext}}` in start and end tag (see
 
 #### options.lineEnding
 Type: `String`
-Default value: `\n`
+Default value: [grunt.util.lineFeed](http://gruntjs.com/api/grunt.util#grunt.util.linefeed)
 
 Configure what `lineEnding` character(s) to use between injections.
 

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
       })(this),
       starttag: '<!-- injector:{{ext}} -->',
       endtag: '<!-- endinjector -->',
-      lineEnding: '\n',
+      lineEnding: grunt.util.linefeed,
       transform: function (filepath) {
         var e = ext(filepath);
         if (e === 'css') {


### PR DESCRIPTION
Resolves issue #37 allowing unit tests to pass on Windows or Mac and allowing injector to use OS settings by default