### PR TITLE
Adding prefix option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,6 +40,14 @@ module.exports = function(grunt) {
           'tmp/defaults.html': ['test/fixtures/*.js', 'test/fixtures/*.css', 'test/fixtures/component.html', '!test/fixtures/*.min.*']
         }
       },
+      prefix: {
+        options: {
+          prefix: 'abc'
+        },
+        files: {
+          'tmp/defaults.html': ['test/fixtures/*.js', 'test/fixtures/*.css', 'test/fixtures/component.html', '!test/fixtures/*.min.*']
+        }
+      },
       templateString: {
         options: {
           template: null,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
           prefix: 'abc'
         },
         files: {
-          'tmp/defaults.html': ['test/fixtures/*.js', 'test/fixtures/*.css', 'test/fixtures/component.html', '!test/fixtures/*.min.*']
+          'tmp/prefix.html': ['test/fixtures/*.js', 'test/fixtures/*.css', 'test/fixtures/component.html', '!test/fixtures/*.min.*']
         }
       },
       templateString: {

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The extension for files collected from from Bower components is prepended with o
 
 #### options.prefix
 Type: `String`
-Default value: ``
+Default value: `''`
 
 Set the prefix to append to the beginning of each injected file. Useful to change the directory name in combination with ignorePath.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ Default value: `<!-- endinjector -->`
 Set the end tag that the injector is looking for. `{{ext}}` is replaced with file extension name, e.g. "css", "js" or "html".
 The extension for files collected from from Bower components is prepended with option `bowerPrefix` if given.
 
+#### options.prefix
+Type: `String`
+Default value: ``
+
+Set the prefix to append to the beginning of each injected file. Useful to change the directory name in combination with ignorePath.
+
 #### options.bowerPrefix
 Type: `String`
 Default value: `NULL`

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -24,6 +24,7 @@ module.exports = function(grunt) {
       template: null,
       bowerPrefix: null,
       relative: false,
+      prefix: '',
       addRootSlash: (function (that) {
         var addRootSlash = true;
         if (that.data.options) {
@@ -152,7 +153,7 @@ module.exports = function(grunt) {
           } else {
             file = removeRootSlash(file);
           }
-          obj.file = file;
+          obj.file = otions.prefix + file;
         });
 
         // Read template:

--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -153,7 +153,7 @@ module.exports = function(grunt) {
           } else {
             file = removeRootSlash(file);
           }
-          obj.file = otions.prefix + file;
+          obj.file = options.prefix + file;
         });
 
         // Read template:

--- a/test/expected/prefix.html
+++ b/test/expected/prefix.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>grunt-injector</title>
+  <!-- injector:html -->
+  <link rel="import" href="abc/../test/fixtures/component.html">
+  <!-- endinjector -->
+  <!-- injector:css -->
+  <link rel="stylesheet" href="abc/../test/fixtures/style.css">
+  <!-- endinjector -->
+  <!-- injector:bower:css -->
+  <!-- endinjector -->
+</head>
+<body>
+
+  <!-- injector:bower:js -->
+  <!-- endinjector -->
+  <!-- injector:js -->
+  <script src="abc/../test/fixtures/script.js"></script>
+  <script src="abc/../test/fixtures/script2.js"></script>
+  <!-- endinjector -->
+</body>
+</html>

--- a/test/expected/prefix.html
+++ b/test/expected/prefix.html
@@ -3,10 +3,10 @@
 <head>
   <title>grunt-injector</title>
   <!-- injector:html -->
-  <link rel="import" href="abc/../test/fixtures/component.html">
+  <link rel="import" href="abc/test/fixtures/component.html">
   <!-- endinjector -->
   <!-- injector:css -->
-  <link rel="stylesheet" href="abc/../test/fixtures/style.css">
+  <link rel="stylesheet" href="abc/test/fixtures/style.css">
   <!-- endinjector -->
   <!-- injector:bower:css -->
   <!-- endinjector -->
@@ -16,8 +16,8 @@
   <!-- injector:bower:js -->
   <!-- endinjector -->
   <!-- injector:js -->
-  <script src="abc/../test/fixtures/script.js"></script>
-  <script src="abc/../test/fixtures/script2.js"></script>
+  <script src="abc/test/fixtures/script.js"></script>
+  <script src="abc/test/fixtures/script2.js"></script>
   <!-- endinjector -->
 </body>
 </html>

--- a/test/injector_test.js
+++ b/test/injector_test.js
@@ -36,6 +36,15 @@ exports.injector = {
 
     test.done();
   },
+  prefix: function(test) {
+    test.expect(1);
+   
+    var actual = grunt.file.read('tmp/prefix.html');
+    var expected = grunt.file.read('test/expected/prefix.html');
+    test.equal(actual, expected, 'should inject stylesheets, scripts and html components into desired file having a prefix added.');
+    
+    test.done();
+  },
   templateString: function(test) {
     test.expect(1);
 


### PR DESCRIPTION
In my case, I'd like to change the path to the scripts in the end. So my "app" folder is not called app anymore. I was sucessful removing it, but I missed an option to prefix the new path with the new folder name. 

Example:

```
 injector: {
                options: {
                    ignorePath: 'app/',
                    addRootSlash: false,
                    prefix: 'cyclone/'
                },
                index: {                   
                    files: {
                        'wwwroot/default/index.html': [
                            'app/**/*.module.js',
                            'app/**/*.js',
                            'app/**/*.css'],
                    }
                }
            }


```