### PR TITLE
Update injector.js

### DIFF
--- a/tasks/injector.js
+++ b/tasks/injector.js
@@ -167,7 +167,15 @@ module.exports = function(grunt) {
             sources.sort(function (a, b) {
               return options.sort(a.file, b.file);
             });
+          } else {
+            //parent dir's files go first.
+            if (options.parentDirFirst) {
+              sources.sort(function (a, b) {
+                return a.file.split("/").length - b.file.split("/").length;
+              });
+            }
           }
+
 
           // Do the injection:
           var re = getInjectorTagsRegExp(starttag, endtag);


### PR DESCRIPTION
Ability to insert files from parent directories first.
In gruntfile.js it's only needed to set option parentDirFrist to true.
injector: {
    options: {
        parentDirFirst: true,
        ...
    }
...
} 
P.S. All credit goes to this guy -> http://stackoverflow.com/users/5795253/necho-musikari