### PR TITLE
Update deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
 > Inject references to files into other files (think scripts and stylesheets into an html file)
 
 ## Getting Started
-This plugin requires Grunt `>=0.4.x`
+Current plugin requires Grunt `~1.0.0` and supports node engine `>=0.10.0`.
+
+Plugin versions `v1.0.1 (and earlier)` require Grunt `>=0.4.x` and support node engine `>= 0.8.0`.
 
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-jshint": "~0.10.0",
-    "grunt-contrib-nodeunit": "~0.4.1"
+    "grunt": "~1.0.0",
+    "grunt-cli": "~1.2.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-nodeunit": "~1.0.0"
   },
   "peerDependencies": {
     "grunt": ">=0.4.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "main": "Gruntfile.js",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">=0.10.0"
   },
   "scripts": {
     "test": "grunt test"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bower"
   ],
   "dependencies": {
-    "wiredep": "~2.2.0",
-    "lodash": "~2.4.1"
+    "wiredep": "~4.0.0",
+    "lodash": "~4.15.0"
   }
 }


### PR DESCRIPTION
Building an application using `node.js v4.5.0 LTS` generates warnings listed at bottom of this request during `npm install`.

This request updates dependencies to newer package versions.
It also reflects the node-engine compatibility set to `>=0.10.0` by `Grunt@1.0.0`.

No more warnings during installation. Verified all tests passing (`npm test`).

Warnings:
```
npm WARN deprecated minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@2.0.10: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated graceful-fs@2.0.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
npm WARN deprecated minimatch@0.3.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated minimatch@1.0.0: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
npm WARN deprecated lodash@0.9.2: Grunt needs your help! See https://github.com/gruntjs/grunt/issues/1403.
npm WARN deprecated graceful-fs@1.2.3: graceful-fs v3.0.0 and before will fail on node releases >= v7.0. Please update to graceful-fs@^4.0.0 as soon as possible. Use 'npm ls graceful-fs' to find it in the tree.
```